### PR TITLE
Fix for NPE on Job status page caused by nullable |items| parameter of renderTable()

### DIFF
--- a/app/views/admin/jobs.html
+++ b/app/views/admin/jobs.html
@@ -44,10 +44,6 @@
 <span class="pull-right">Time: ${new Date()}</span>
 <h2>Poller Jobs <small><a href="@{Admin.runJobManually('poller')}">Run</a></small></h2>
 ${renderTable(pollerJobs)}
-<h2>Health Check Jobs <small><a href="@{Admin.runJobManually('healthcheck')}">Run</a></small></h2>
-${renderTable(healthCheckJobs)}
-<h2>Cleanup Jobs <small><a href="@{Admin.runJobManually('cleanup')}">Run</a></small></h2>
-${renderTable(cleanupJobs)}
 <script type="text/javascript">
 	$(document).ready(function() {
 		$("a.show-stack-trace").click(function() {

--- a/app/views/admin/jobs.html
+++ b/app/views/admin/jobs.html
@@ -1,6 +1,6 @@
 #{extends "admin/index.html" /}
 %{ def renderTable = { items -> }%
-	#{if items.size > 0}
+	#{if items?.size > 0}
 	<table class="table table-condensed">
 		<tr>
 			<th style="width:15%">Title</th>


### PR DESCRIPTION
Stacktrace while browsing `/admin/jobs`:
```
Internal Server Error (500) for request GET /admin/jobs

Template execution error (In /app/views/admin/jobs.html around line 3)
Execution error occured in template /app/views/admin/jobs.html. Exception raised was NullPointerException : Cannot get property 'size' on null object.

play.exceptions.TemplateExecutionException: Cannot get property 'size' on null object
	at play.templates.BaseTemplate.throwException(BaseTemplate.java:86)
	at play.templates.GroovyTemplate.internalRender(GroovyTemplate.java:272)
	at play.templates.Template.render(Template.java:26)
	at play.templates.GroovyTemplate.render(GroovyTemplate.java:202)
	at play.mvc.results.RenderTemplate.<init>(RenderTemplate.java:24)
	at play.mvc.Controller.renderTemplate(Controller.java:661)
	at play.mvc.Controller.renderTemplate(Controller.java:641)
	at play.mvc.Controller.render(Controller.java:696)
	at controllers.Admin.jobs(Admin.java:185)
	at play.mvc.ActionInvoker.invokeWithContinuation(ActionInvoker.java:557)
	at play.mvc.ActionInvoker.invoke(ActionInvoker.java:508)
	at play.mvc.ActionInvoker.invokeControllerMethod(ActionInvoker.java:484)
	at play.mvc.ActionInvoker.invokeControllerMethod(ActionInvoker.java:479)
	at play.mvc.ActionInvoker.invoke(ActionInvoker.java:161)
	at Invocation.HTTP Request(Play!)
Caused by: java.lang.NullPointerException: Cannot get property 'size' on null object
	at /app/views/admin/jobs.html.(line:3)
	at /app/views/admin/jobs.html.(line:48)
	at play.templates.GroovyTemplate.internalRender(GroovyTemplate.java:247)
	... 13 more
```

Also removed the two defunct jobs from the view.